### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,18 +27,17 @@ Author: Torsten Harenberg, DL1THM (initial) with large contributions and bug fix
 #### Compiling
 
 
-The PACTOR support is beta and not included in the standard distribution of [Pat](http://getpat.io) yet. 
-You need to build a version of Pat manually, however it is not difficult to do so. The Pat version with PACTOR support is
-available as a seperate branch in the source tree. This [build script](https://github.com/la5nta/pat/blob/master/make.bash) will pull all dependencies, including this driver. So you do not need to bother with this repository.
+The PACTOR support is beta and ~~not~~ included in the standard distribution of [Pat](http://getpat.io) since v0.7.0. 
+To get the latest PACTOR updates you may want to build a version of Pat manually, however it is not difficult to do so. The Pat version with PACTOR support is available as a seperate branch in the source tree. This [build script](https://github.com/la5nta/pat/blob/master/make.bash) will pull all dependencies, including this driver. So you do not need to bother with this repository.
 
 Some very basic knowledge of using the [Go programming language](https://golang.org/) is helpful. But you do not need to write own code!
 
 If you haven't done yet, [download](https://golang.org/dl/) and [install](https://golang.org/doc/install) Go. Get familiar with [the workspace](https://golang.org/doc/code.html#Workspaces). 
 
-Now go to your GO src directory and issue
+Now go to your GO src (default: $HOME/go/src) directory and issue
 
 ```
-git clone -b feature/ptc-support https://github.com/la5nta/pat github.com/la5nta/pat
+git clone -b develop https://github.com/la5nta/pat github.com/la5nta/pat
 cd github.com/la5nta/pat
 ./make.bash libax25
 ./make.bash
@@ -51,11 +50,11 @@ That will create the binary into the current directory, you may want to move it 
 Once you have successfully compiled Pat as described above, [configure it](https://github.com/la5nta/pat/wiki/The-command-line-interface#configure). Afterwards you should add an entry to your $HOME/.wl2k/config.json file like this:
 
 ```json
-	"pactor": {
-	"path": "/dev/ttyUSB0",
-	"rig": "",
-	"custom_init_script": "/home/pi/ptcinit.txt"
-	},
+  "pactor": {
+    "path": "/dev/ttyUSB0",
+    "rig": "",
+    "custom_init_script": "/home/pi/ptcinit.txt"
+  },
 ```
 
 Path is the tty to your SCS modem. The example here is from Linux and I haven't tested this on any other platform yet.
@@ -134,6 +133,7 @@ which is not supported by the underlying Go package. And I do not own one of the
 being, these new modems are unfortunately **not** supported, 
 although there has been some [effort](https://github.com/harenber/ptc-go/tree/feature/p4-dragon) from Martin, LA4NTA, to get those modems running as well. If you
 think you can contribute, please feel free to comment on [issue #3](https://github.com/harenber/ptc-go/issues/3). 
+
 ## What is missing
 
 There are a lot of features that would be nice to have and which are


### PR DESCRIPTION
I'm getting ready for Pat v0.7.0 release (🍾) and have updated the README.md to say that building from source will no longer be required.

I guess we are going to see (more or less) rapid development in the PACTOR driver as bug reports and suggestions come in.. so I'm proposing that we include the build instructions for the `develop` branch of Pat for now.

What do you think @harenber? Feel free to merge if you think it looks good :)