### PR TITLE
Read env 'PACTOR_DEBUG' instead of 'pactor_debug'

### DIFF
--- a/pactor/pactor.go
+++ b/pactor/pactor.go
@@ -32,14 +32,13 @@ type State uint8
 var debugMux sync.Mutex
 
 func debugEnabled() int {
-	if value, ok := os.LookupEnv("pactor_debug"); ok {
+	if value, ok := os.LookupEnv("PACTOR_DEBUG"); ok {
 		level, err := strconv.Atoi(value)
 		if err == nil {
 			return level
 		}
 	}
 	return 0
-
 }
 
 func writeDebug(message string, level int) {


### PR DESCRIPTION
After introducing the PAT_DEBUG environment variable, I realize that we should use all upper case for most env variables.

I've done similar changes in wl2k-go.